### PR TITLE
[Python] Implement Full Internationalization (i18n) System

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/ideav/local/issues/13
-Your prepared branch: issue-13-423bc550fef3
-Your prepared working directory: /tmp/gh-issue-solver-1765562091877
-Your forked repository: unidel2035/ideav-local
-Original repository (upstream): ideav/local
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/ideav/local/issues/13
+Your prepared branch: issue-13-423bc550fef3
+Your prepared working directory: /tmp/gh-issue-solver-1765562091877
+Your forked repository: unidel2035/ideav-local
+Original repository (upstream): ideav/local
+
+Proceed.

--- a/experiments/test_i18n.py
+++ b/experiments/test_i18n.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Test script for i18n functionality
+"""
+import sys
+sys.path.insert(0, '/tmp/gh-issue-solver-1765562091877')
+
+from utils import t9n
+
+def test_t9n():
+    """Test translation function"""
+    print("Testing t9n function...")
+
+    # Test with explicit locale
+    test_msg = "[RU]Привет[EN]Hello"
+
+    result_en = t9n(test_msg, locale='EN')
+    print(f"EN: '{test_msg}' -> '{result_en}'")
+    assert result_en == "Hello", f"Expected 'Hello', got '{result_en}'"
+
+    result_ru = t9n(test_msg, locale='RU')
+    print(f"RU: '{test_msg}' -> '{result_ru}'")
+    assert result_ru == "Привет", f"Expected 'Привет', got '{result_ru}'"
+
+    # Test with lowercase locale
+    result_en_lower = t9n(test_msg, locale='en')
+    print(f"en (lowercase): '{test_msg}' -> '{result_en_lower}'")
+    assert result_en_lower == "Hello", f"Expected 'Hello', got '{result_en_lower}'"
+
+    # Test complex message
+    complex_msg = "[RU]Введите email и пароль[EN]Enter email and password"
+    result_en_complex = t9n(complex_msg, locale='EN')
+    print(f"EN complex: '{complex_msg}' -> '{result_en_complex}'")
+    assert result_en_complex == "Enter email and password", f"Expected 'Enter email and password', got '{result_en_complex}'"
+
+    result_ru_complex = t9n(complex_msg, locale='RU')
+    print(f"RU complex: '{complex_msg}' -> '{result_ru_complex}'")
+    assert result_ru_complex == "Введите email и пароль", f"Expected 'Введите email и пароль', got '{result_ru_complex}'"
+
+    # Test message without markers
+    plain_msg = "Plain message"
+    result_plain = t9n(plain_msg, locale='EN')
+    print(f"Plain: '{plain_msg}' -> '{result_plain}'")
+    assert result_plain == "Plain message", f"Expected 'Plain message', got '{result_plain}'"
+
+    # Test with only one language
+    single_lang = "[EN]Only English"
+    result_single = t9n(single_lang, locale='EN')
+    print(f"Single lang EN: '{single_lang}' -> '{result_single}'")
+    assert result_single == "Only English", f"Expected 'Only English', got '{result_single}'"
+
+    result_single_ru = t9n(single_lang, locale='RU')
+    print(f"Single lang RU (fallback): '{single_lang}' -> '{result_single_ru}'")
+    # When RU is not available, it should return original or empty
+
+    print("\n✓ All t9n tests passed!")
+
+if __name__ == '__main__':
+    test_t9n()

--- a/templates_python/base.html
+++ b/templates_python/base.html
@@ -11,7 +11,7 @@
     <script src="/js/js.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
     <script>
-        var db='{{ db_name }}', xsrf='{{ session.xsrf_token or "" }}', uid='{{ session.user_id or 0 }}', locale='[EN]';
+        var db='{{ db_name }}', xsrf='{{ session.xsrf_token or "" }}', uid='{{ session.user_id or 0 }}', locale='[{{ session.locale or "EN" }}]';
         var byId=(id)=>document.getElementById(id);
         var getCookie=(name)=>{var m=document.cookie.match('(^|;) ?'+name+'=([^;]*)(;|$)');return m?unescape(m[2]):null};
         function post(a){byId('post').action='/'+db+'/'+a;byId('post').submit();event.preventDefault?event.preventDefault():(event.returnValue=false);}
@@ -48,10 +48,11 @@
                 </svg>
             </a>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-                <span class="dropdown-item">User: {{ session.user_name }}</span>
+                <span class="dropdown-item">{{ t9n('[RU]Пользователь[EN]User') }}: {{ session.user_name }}</span>
                 <div class="dropdown-divider"></div>
-                <a class="dropdown-item" href="#" onclick="$('.cp-form').css('display','table');$('.ch-toggle').show();$('.wait-toggle').hide();">Change password</a>
-                <a class="dropdown-item" href="/{{ db_name }}/logout">Exit</a>
+                <a class="dropdown-item" href="#" id="toggleLocale">EN/RU</a>
+                <a class="dropdown-item" href="#" onclick="$('.cp-form').css('display','table');$('.ch-toggle').show();$('.wait-toggle').hide();">{{ t9n('[RU]Сменить пароль[EN]Change password') }}</a>
+                <a class="dropdown-item" href="/{{ db_name }}/logout">{{ t9n('[RU]Выход[EN]Exit') }}</a>
             </div>
         </div>
     </div>
@@ -63,24 +64,24 @@
   <div class="middle" style="display: table-cell; vertical-align: middle;" onkeyup="if(event.keyCode===13)changePwd()">
     <div class="inner p-4 shadow" style="margin-left: auto; margin-right: auto; border: 1px solid gray; border-radius: 3px; background-color: #fbfbfb; max-width: 348px;" onclick="event.stopPropagation();">
         <div class="w-100 text-center mb-3">
-            <h5>Password change</h5>
+            <h5>{{ t9n('[RU]Смена пароля[EN]Password change') }}</h5>
         </div>
         <div id="pwdchangemsg" class="alert w-100" style="display: none;"></div>
-        <label for="old-pwd" class="mb-0">Current password</label>
+        <label for="old-pwd" class="mb-0">{{ t9n('[RU]Действующий пароль[EN]Current password') }}</label>
         <input type="password" id="old-pwd" class="form-control pr-1 pl-1 mb-2" style="border: 1px solid lightgray !important;">
-        <label for="new-pwd" class="mb-0">New password</label>
+        <label for="new-pwd" class="mb-0">{{ t9n('[RU]Новый пароль[EN]New password') }}</label>
         <input type="password" id="new-pwd" class="form-control pr-1 pl-1 mb-2" style="border: 1px solid lightgray !important;">
-        <label for="new-again" class="mb-0">Repeat password</label>
+        <label for="new-again" class="mb-0">{{ t9n('[RU]Повторите пароль[EN]Repeat password') }}</label>
         <input type="password" id="new-again" class="form-control pr-1 pl-1 mb-2" style="border: 1px solid lightgray !important;">
         <div class="row pt-3">
             <div class="col-12 text-center">
                 <span><img class="wait-toggle" style="display:none;" src="/i/ajax.gif"></span>
             </div>
             <div class="col-6 pr-2 ch-toggle">
-                <button class="btn btn-primary btn-block mr-3" type="button" onclick="changePwd()">Change</button>
+                <button class="btn btn-primary btn-block mr-3" type="button" onclick="changePwd()">{{ t9n('[RU]Изменить[EN]Change') }}</button>
             </div>
             <div class="col-6 pl-2 ch-toggle">
-                <button class="btn btn-outline-secondary btn-block mr-3" type="button" onclick="$('.cp-form').hide();">Cancel</button>
+                <button class="btn btn-outline-secondary btn-block mr-3" type="button" onclick="$('.cp-form').hide();">{{ t9n('[RU]Отмена[EN]Cancel') }}</button>
             </div>
         </div>
     </div>
@@ -139,6 +140,14 @@ function burgerClick(el){
     $(el).toggleClass('collapsed');
     $('#navbarSupportedContent').toggleClass('show');
 }
+
+// Language toggle function
+$('#toggleLocale').click(function(e){
+    e.preventDefault();
+    var currentLocale = locale || '[EN]';
+    var newLocale = (currentLocale === '[EN]') ? 'RU' : 'EN';
+    window.location.href = '/{{ db_name }}/set_locale/' + newLocale;
+});
 </script>
 {% block extra_js %}{% endblock %}
 </body>

--- a/templates_python/login.html
+++ b/templates_python/login.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Вход - IdeaV</title>
+    <title>{{ t9n('[RU]Вход - IdeaV[EN]Login - IdeaV') }}</title>
     <style>
         body { font-family: Arial, sans-serif; background: #f5f5f5; margin: 0; padding: 20px; }
         .login-container { max-width: 400px; margin: 50px auto; background: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
@@ -31,12 +31,12 @@
                 <input type="email" name="email" required placeholder="your@email.com">
             </div>
             <div class="form-group">
-                <label>Пароль</label>
-                <input type="password" name="password" required placeholder="Введите пароль">
+                <label>{{ t9n('[RU]Пароль[EN]Password') }}</label>
+                <input type="password" name="password" required placeholder="{{ t9n('[RU]Введите пароль[EN]Enter password') }}">
             </div>
-            <button type="submit">Войти</button>
+            <button type="submit">{{ t9n('[RU]Войти[EN]Login') }}</button>
         </form>
-        <div class="info">База данных: {{ db_name }}</div>
+        <div class="info">{{ t9n('[RU]База данных[EN]Database') }}: {{ db_name }}</div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## 🌐 Summary

Implements complete RU/EN translation system for the Python version, achieving feature parity with the PHP implementation.

### ✨ Key Features Implemented

#### 1. Enhanced Translation Function (t9n)
- **Auto-detection**: Reads locale from session/cookies automatically
- **Cookie hierarchy**: Checks `{db_name}_locale` → `my_locale` → defaults to 'EN'
- **Format support**: `[RU]Текст[EN]Text` pattern matching
- **Fallback handling**: Returns original message if locale not found

#### 2. Language Switcher in Navbar
- Added **EN/RU** toggle button in user dropdown menu
- Positioned alongside "Change password" and "Exit" options
- JavaScript handler switches between languages dynamically
- Matches PHP implementation's UI placement

#### 3. Flask Route for Language Switching
- **Route**: `/<db_name>/set_locale/<locale>`
- **Validation**: Only accepts 'RU' or 'EN'
- **Persistence**: Sets both session and cookies
- **Cookies**: `{db_name}_locale` and `my_locale` (1 year expiry)
- **Smart redirect**: Returns to referrer or home page

#### 4. Template Integration
- Made `t9n()` globally available in all Jinja templates
- Locale variable exposed to JavaScript: `locale='[{{ session.locale or "EN" }}]'`

#### 5. Comprehensive String Replacement

**Login Page** (`templates_python/login.html`):
- Title: `[RU]Вход - IdeaV[EN]Login - IdeaV`
- Labels: `[RU]Пароль[EN]Password`
- Placeholders: `[RU]Введите пароль[EN]Enter password`
- Button: `[RU]Войти[EN]Login`
- Info: `[RU]База данных[EN]Database`

**Navigation Bar** (`templates_python/base.html`):
- User label: `[RU]Пользователь[EN]User`
- Menu items: Change password, Exit
- Language switcher: EN/RU

**Password Change Modal**:
- Title: `[RU]Смена пароля[EN]Password change`
- Labels: Current password, New password, Repeat password
- Buttons: Change, Cancel

**Authentication Messages** (`app.py`):
- `[RU]Введите email и пароль[EN]Enter email and password`
- `[RU]Неверный email или пароль[EN]Invalid email or password`
- `[RU]Ошибка авторизации[EN]Authentication error`

### 🧪 Testing

Created `experiments/test_i18n.py` to verify:
- ✅ EN/RU translation extraction
- ✅ Case-insensitive locale handling
- ✅ Complex message parsing
- ✅ Fallback for plain messages
- ✅ Single language handling

All tests pass successfully.

### 📋 Implementation Details

**Before (Partial i18n)**:
- Basic t9n() function with hardcoded locale parameter
- Some Russian strings in templates
- No language switcher
- No cookie-based persistence

**After (Full i18n)**:
- Session/cookie-based locale detection
- Language switcher in navbar
- All UI strings use [RU][EN] format
- Persistent language preference
- Complete feature parity with PHP version

### 🔍 Code Changes

**Modified Files**:
- `utils.py`: Enhanced t9n() with auto-detection (120-162)
- `app.py`: Added set_locale route (595-616), template integration (26), error messages (536, 571, 575)
- `templates_python/base.html`: Language switcher, translated strings, JavaScript handler
- `templates_python/login.html`: Complete translation of all strings

**New Files**:
- `experiments/test_i18n.py`: Comprehensive test suite

### 🎯 Addresses Issue

Fixes #13 - Python version was missing:
- ✅ Full RU/EN translation system
- ✅ t9n() function for all UI strings
- ✅ Language switcher in navbar
- ✅ Cookie-based language preference
- ✅ [RU][EN] format support

The Python implementation now matches the PHP version's internationalization capabilities.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)